### PR TITLE
Tweak trait_alias usage, build on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ readme = "README.md"
 [dependencies]
 utf8-decode = "^1.0"
 source-span = "^2.2"
+
+[features]
+nightly = []

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -224,4 +224,10 @@ where L: fmt::Display, C: fmt::Display {
 	}
 }
 
+// TODO: unify once the unstable feature is stabilized.
+#[cfg(feature = "nightly")]
 pub trait Function = Clone + Hash + Eq + fmt::Display;
+#[cfg(not(feature = "nightly"))]
+pub trait Function: Clone + Hash + Eq + fmt::Display {}
+#[cfg(not(feature = "nightly"))]
+impl<T> Function for T where T: Clone + Hash + Eq + fmt::Display {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
-#![feature(trait_alias)]
-
-extern crate source_span;
+#![cfg_attr(feature = "nightly", feature(trait_alias))]
 
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -822,7 +820,13 @@ pub trait Function<E: Environment> {
 	// fn typecheck(&self, checker: &mut TypeChecker<E::Sort>, env: &E, args: &[TypeRef<E::Sort>], return_sort: TypeRef<E::Sort>);
 }
 
+// TODO: unify once the unstable feature is stabilized.
+#[cfg(feature = "nightly")]
 pub trait Sort = Clone + PartialEq + fmt::Debug;
+#[cfg(not(feature = "nightly"))]
+pub trait Sort: Clone + PartialEq + fmt::Debug {}
+#[cfg(not(feature = "nightly"))]
+impl<T> Sort for T where T: Clone + PartialEq + fmt::Debug {}
 
 /// SMT2-lib solver environment.
 pub trait Environment: Sized {


### PR DESCRIPTION
This tweaks an unstable feature usage, now allowing to build this crate on a stable toolchain.